### PR TITLE
feat: Add ability for protocol to be defaulted if missing from URL spec

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/mitchellh/consulstructure v0.0.0-20190329231841-56fdc4d2da54
 	github.com/mitchellh/copystructure v1.0.0 // indirect
 	github.com/pelletier/go-toml v1.2.0
-	github.com/stretchr/testify v1.3.0
+	github.com/stretchr/testify v1.5.1
 )
 
 go 1.13

--- a/pkg/types/config_test.go
+++ b/pkg/types/config_test.go
@@ -1,0 +1,134 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package types
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetUrl(t *testing.T) {
+	expected := "https://localhost:8080"
+	target := ServiceConfig{
+		Protocol: "https",
+		Host:     "localhost",
+		Port:     8080,
+		Type:     "consul",
+	}
+
+	actual := target.GetUrl()
+	assert.Equal(t, expected, actual)
+}
+
+func TestGetProtocol(t *testing.T) {
+	testCases := []struct {
+		Name     string
+		Protocol string
+		Expected string
+	}{
+		{
+			Name:     "Protocol Specified",
+			Protocol: "https",
+			Expected: "https",
+		},
+		{
+			Name:     "Protocol Not Specified",
+			Protocol: "",
+			Expected: "http",
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.Name, func(t *testing.T) {
+			target := ServiceConfig{
+				Protocol: test.Protocol,
+			}
+
+			actual := target.GetProtocol()
+			assert.Equal(t, test.Expected, actual)
+		})
+	}
+}
+
+func TestPopulateFromUrl(t *testing.T) {
+	testCases := []struct {
+		Name             string
+		Url              string
+		ExpectedType     string
+		ExpectedProtocol string
+		ExpectedHost     string
+		ExpectedPort     int
+		ExpectedError    string
+	}{
+		{
+			Name:             "Success, protocol specified",
+			Url:              "consul.https://localhost:8080",
+			ExpectedType:     "consul",
+			ExpectedProtocol: "https",
+			ExpectedHost:     "localhost",
+			ExpectedPort:     8080,
+		},
+		{
+			Name:             "Success, protocol not specified",
+			Url:              "consul://localhost:8080",
+			ExpectedType:     "consul",
+			ExpectedProtocol: "http",
+			ExpectedHost:     "localhost",
+			ExpectedPort:     8080,
+		},
+		{
+			Name:          "Bad URL format",
+			Url:           "not a url\r\n",
+			ExpectedError: "the format of Provider URL is incorrect",
+		},
+		{
+			Name:          "Bad Port",
+			Url:           "consul.https:\\localhost:eight",
+			ExpectedError: "the port from Provider URL is incorrect",
+		},
+		{
+			Name:          "Missing Type and Protocol spec",
+			Url:           "://localhost:800",
+			ExpectedError: "missing protocol scheme",
+		},
+		{
+			Name:          "Bad Type and Protocol spec",
+			Url:           "xyz.consul.http://localhost:800",
+			ExpectedError: "the Type and Protocol spec from Provider URL is incorrect",
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.Name, func(t *testing.T) {
+			target := ServiceConfig{}
+
+			err := target.PopulateFromUrl(test.Url)
+			if test.ExpectedError != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), test.ExpectedError)
+				return // test is complete
+			}
+
+			assert.Equal(t, test.ExpectedType, target.Type)
+			assert.Equal(t, test.ExpectedProtocol, target.Protocol)
+			assert.Equal(t, test.ExpectedHost, target.Host)
+			assert.Equal(t, test.ExpectedPort, target.Port)
+		})
+	}
+}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://wiki.edgexfoundry.org/display/FA/Contributor%27s+Guide
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
ServiceConfig.PopulateFromUrl() will return error if protocol is missing , i.e. 'consul://edgex-consul:8500'

Issue Number: #9

## What is the new behavior?

Now the missing protocol is defaulted to `http`

This is in support of Device SDK using go-mod-bootstrap and backwards support for `--registry=<url>`.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No


## Are there any specific instructions or things that should be known prior to reviewing?

## Other information