### PR TITLE
feat: Add new HasSubConfiguration(name string) API

### DIFF
--- a/configuration/interface.go
+++ b/configuration/interface.go
@@ -24,6 +24,9 @@ type Client interface {
 	// Checks to see if the Configuration service contains the service's configuration.
 	HasConfiguration() (bool, error)
 
+	// Checks to see if the Configuration service contains the service's sub configuration.
+	HasSubConfiguration(name string) (bool, error)
+
 	// Puts a full toml configuration into the Configuration service
 	PutConfigurationToml(configuration *toml.Tree, overwrite bool) error
 

--- a/internal/pkg/consul/client.go
+++ b/internal/pkg/consul/client.go
@@ -91,6 +91,17 @@ func (client *consulClient) HasConfiguration() (bool, error) {
 	}
 }
 
+// Checks to see if the Configuration service contains the service's sub configuration.
+func (client *consulClient) HasSubConfiguration(name string) (bool, error) {
+	if stemKeys, _, err := client.consulClient.KV().Keys(client.fullPath(name), "", nil); err != nil {
+		return false, fmt.Errorf("checking sub configuration existence from Consul failed: %v", err)
+	} else if len(stemKeys) == 0 {
+		return false, nil
+	} else {
+		return true, nil
+	}
+}
+
 // Puts a full toml configuration into Consul
 func (client *consulClient) PutConfigurationToml(configuration *toml.Tree, overwrite bool) error {
 

--- a/internal/pkg/consul/client_test.go
+++ b/internal/pkg/consul/client_test.go
@@ -160,6 +160,55 @@ func TestHasConfigurationError(t *testing.T) {
 	assert.Contains(t, err.Error(), "checking configuration existence")
 }
 
+func TestHasSubConfigurationFalse(t *testing.T) {
+	client := makeConsulClient(t, getUniqueServiceName())
+
+	// Make sure the configuration doesn't already exists
+	reset(t, client)
+
+	// Now push a value so some configuration will exist
+	_ = client.PutConfigurationValue("Dummy", []byte("Value"))
+
+	actual, err := client.HasSubConfiguration("subDummy")
+	if !assert.NoError(t, err) {
+		t.Fatal()
+	}
+
+	assert.False(t, actual)
+}
+
+func TestHasSubConfigurationTrue(t *testing.T) {
+	client := makeConsulClient(t, getUniqueServiceName())
+
+	// Make sure the configuration doesn't already exists
+	reset(t, client)
+
+	// Now push a value so some configuration will exist
+	_ = client.PutConfigurationValue("Dummy", []byte("Value"))
+
+	actual, err := client.HasSubConfiguration("Dummy")
+	if !assert.NoError(t, err) {
+		t.Fatal()
+	}
+
+	assert.True(t, actual)
+}
+
+func TestHasSubConfigurationError(t *testing.T) {
+	goodPort := port
+	port = 1234 // change the Consul port to bad port
+	defer func() {
+		port = goodPort
+	}()
+
+	client := makeConsulClient(t, getUniqueServiceName())
+
+	_, err := client.HasSubConfiguration("dummy")
+	assert.Error(t, err, "expected error checking configuration existence")
+
+	assert.Contains(t, err.Error(), "checking sub configuration existence")
+}
+
 func TestConfigurationValueExists(t *testing.T) {
 	key := "Foo"
 	value := []byte("bar")


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-configuration/blob/master/.github/Contributing.md.

## What is the current behavior?
No API that allows to check for existence of a sub configuration 

## Issue Number:  #28


## What is the new behavior?
New `HasSubConfiguration(name string)` API checks for the existence of the named sub configuration


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information