### PR TITLE
feat(security): support ACL access token

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ type ServiceConfig struct {
 	Port int
 	Type string
 	BasePath string
+	AccessToken string
 }
 ```
 
@@ -43,6 +44,7 @@ func initializeConfiguration(useConfigService bool, useProfile string) (*Configu
             Port:            conf.Configuration.Port,
             Type:            conf.Configuration.Type,
             BasePath:        internal.ConfigStem + internal.MyServiceKey,
+            AccessToken:     <AccessTokenLoadedFromSecretFile>,
         }
 
         ConfigClient, err = configuration.NewConfigurationClient(serviceConfig)

--- a/configuration/factory.go
+++ b/configuration/factory.go
@@ -26,7 +26,7 @@ import (
 func NewConfigurationClient(config types.ServiceConfig) (Client, error) {
 
 	if config.Host == "" || config.Port == 0 {
-		return nil, fmt.Errorf("unable to create Configuation Client: Configuation service host and/or port or serviceKey not set")
+		return nil, fmt.Errorf("unable to create Configuration Client: Configuration service host and/or port or serviceKey not set")
 	}
 
 	switch config.Type {

--- a/internal/pkg/consul/client.go
+++ b/internal/pkg/consul/client.go
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Intel Corporation
+// Copyright (c) 2021 Intel Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -55,6 +55,7 @@ func NewConsulClient(config types.ServiceConfig) (*consulClient, error) {
 	var err error
 
 	client.consulConfig = consulapi.DefaultConfig()
+	client.consulConfig.Token = config.AccessToken
 	client.consulConfig.Address = client.consulUrl
 	client.consulClient, err = consulapi.NewClient(client.consulConfig)
 	if err != nil {

--- a/pkg/types/config.go
+++ b/pkg/types/config.go
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Intel Corporation
+// Copyright (c) 2021 Intel Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -38,6 +38,8 @@ type ServiceConfig struct {
 	Type string
 	// BasePath is the base path with in the Configuration service where the your service's configuration is stored
 	BasePath string
+	// AccessToken is the token that is used to access the service configuration
+	AccessToken string
 }
 
 //


### PR DESCRIPTION
Add `AccessToken` in config to allow to setting the token to access the configuration.

Closes: #22

Signed-off-by: Jim Wang <yutsung.jim.wang@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-configuration/blob/master/.github/Contributing.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
no access token in place

## Issue Number:  #22 


## What is the new behavior?
Add an ability to set access token in config

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x ] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x ] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information