### PR TITLE
"build(deps): revert the bump github.com/pelletier/go-toml from 1.2.0 to 1.9.0"

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,12 +1,14 @@
 module github.com/edgexfoundry/go-mod-configuration/v2
 
 require (
+	github.com/BurntSushi/toml v0.3.1 // indirect
 	github.com/cenkalti/backoff v2.2.1+incompatible // indirect
 	github.com/hashicorp/consul/api v1.8.1
 	github.com/mitchellh/consulstructure v0.0.0-20190329231841-56fdc4d2da54
 	github.com/mitchellh/copystructure v1.0.0 // indirect
-	github.com/pelletier/go-toml v1.9.0
+	github.com/pelletier/go-toml v1.2.0
 	github.com/stretchr/testify v1.7.0
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 )
 
 go 1.15


### PR DESCRIPTION
Reverts edgexfoundry/go-mod-configuration#31