### PR TITLE
fix: Fix service not apply config change

### DIFF
--- a/internal/pkg/keeper/client.go
+++ b/internal/pkg/keeper/client.go
@@ -210,8 +210,8 @@ func (k *keeperClient) WatchForChanges(updateChannel chan<- interface{}, errorCh
 			case e := <-watchErrors:
 				errorChannel <- e
 			case msgEnvelope := <-messages:
-				if msgEnvelope.ContentType != common.ContentTypeJSON {
-					errorChannel <- fmt.Errorf("invalid content type of configuration changes message, expected: %s, but got: %s", common.ContentTypeJSON, msgEnvelope.ContentType)
+				if msgEnvelope.ContentType != common.ContentTypeJSON && msgEnvelope.ContentType != common.ContentTypeCBOR {
+					errorChannel <- fmt.Errorf("invalid content type of configuration changes message, expected: %s or %s, but got: %s", common.ContentTypeJSON, common.ContentTypeCBOR, msgEnvelope.ContentType)
 					continue
 				}
 				var updatedConfig models.KVS
@@ -236,8 +236,13 @@ func (k *keeperClient) WatchForChanges(updateChannel chan<- interface{}, errorCh
 					for _, c := range kvConfigs.Response {
 						if c.Key == updatedConfig.Key {
 							// if the updated value in the message payload is different from the one obtained by Keeper
-							// skip this subscribed message payload and continue the outer loop
-							if c.Value != updatedConfig.Value {
+							//   skip this subscribed message payload and continue the outer loop
+							// if the updated value in the message payload is equal to the one obtained by Keeper
+							//   decode the kvConfigs with the configuration struct
+
+							// convert the message payload value to string for value comparison, because the value retrieved from the Keeper is always a string, but the value from the message payload may be either a string, bool, or float.
+							updatedValueStr := fmt.Sprintf("%v", updatedConfig.Value)
+							if c.Value != updatedValueStr {
 								continue outerLoop
 							}
 							break

--- a/internal/pkg/keeper/client.go
+++ b/internal/pkg/keeper/client.go
@@ -235,12 +235,9 @@ func (k *keeperClient) WatchForChanges(updateChannel chan<- interface{}, errorCh
 				if updatedConfig.Key != keyPrefix {
 					for _, c := range kvConfigs.Response {
 						if c.Key == updatedConfig.Key {
+							// convert the updatedConfig.Value to string for value comparison, because the value retrieved from the Keeper is always a string, but the value from the message payload may be either a string, bool, or float.
 							// if the updated value in the message payload is different from the one obtained by Keeper
-							//   skip this subscribed message payload and continue the outer loop
-							// if the updated value in the message payload is equal to the one obtained by Keeper
-							//   decode the kvConfigs with the configuration struct
-
-							// convert the message payload value to string for value comparison, because the value retrieved from the Keeper is always a string, but the value from the message payload may be either a string, bool, or float.
+							// skip this subscribed message payload and continue the outer loop
 							updatedValueStr := fmt.Sprintf("%v", updatedConfig.Value)
 							if c.Value != updatedValueStr {
 								continue outerLoop


### PR DESCRIPTION
Convert the message payload value to string for comparison, because the value retrieved from the Keeper is always a string, but the value from the message payload may be either a string, bool, or float.

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-configuration/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-configuration/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?) not impact
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?) not impact
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
Deploy core services and test the PUT API
```
curl --request PUT 'http://localhost:59890/api/v3/kvs/key/edgex/v4/core-metadata/Writable/MaxDevices'  \
--data '{ "value": 12 }'
```
## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->