### PR TITLE
fix: Replace fmt.Sprintf("%v",v) with cast.ToString(v)

### DIFF
--- a/internal/pkg/keeper/client.go
+++ b/internal/pkg/keeper/client.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/edgexfoundry/go-mod-core-contracts/v4/dtos/requests"
 	"github.com/edgexfoundry/go-mod-core-contracts/v4/models"
-	"github.com/spf13/cast"
 
 	httpClient "github.com/edgexfoundry/go-mod-core-contracts/v4/clients/http"
 	"github.com/edgexfoundry/go-mod-core-contracts/v4/clients/interfaces"
@@ -24,6 +23,8 @@ import (
 	msgTypes "github.com/edgexfoundry/go-mod-messaging/v4/pkg/types"
 
 	"github.com/edgexfoundry/go-mod-configuration/v4/pkg/types"
+
+	"github.com/spf13/cast"
 )
 
 const (
@@ -238,7 +239,7 @@ func (k *keeperClient) WatchForChanges(updateChannel chan<- interface{}, errorCh
 							// convert the updatedConfig.Value to string for value comparison, because the value retrieved from the Keeper is always a string, but the value from the message payload may be either a string, bool, or float.
 							// if the updated value in the message payload is different from the one obtained by Keeper
 							// skip this subscribed message payload and continue the outer loop
-							updatedValueStr := fmt.Sprintf("%v", updatedConfig.Value)
+							updatedValueStr := cast.ToString(updatedConfig.Value)
 							if c.Value != updatedValueStr {
 								continue outerLoop
 							}


### PR DESCRIPTION
Replace fmt.Sprintf("%v",v) with cast.ToString(v) to ensure consistent string conversion and avoid scientific notation for float values.

fix: #213 

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
1. Use [app-service-template](https://github.com/edgexfoundry/app-functions-sdk-go/tree/main/app-service-template) for testing
2. Add a float value to the AppCustom configuration and launch app-service-template
3. Modify the float value through the core-keeper API
4. The app-service-template's ProcessConfigUpdates function, which is a callback function invoked when the custom config changes, should be triggered and print a log.

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->